### PR TITLE
Prevent race condition in POST request handling

### DIFF
--- a/src/main/kotlin/com/fairviewcodeclub/snek/logic/World.kt
+++ b/src/main/kotlin/com/fairviewcodeclub/snek/logic/World.kt
@@ -81,6 +81,7 @@ class World(participants: Array<SnekColor> = SnekColor.values()) {
     /**
      * Takes a turn direction for a snek
      */
+    @Synchronized
     fun acceptQueueRequest(sender: SnekColor, turnDirection: Int) {
         this.sneks.first { it.color == sender }.queuedTurn = turnDirection
         if (this.waitingOn.contains(sender)) {


### PR DESCRIPTION
Stop multiple threads handling a POST to /api from editing `world.waitingOn` at the same time. Such editing could cause a `null` to be placed in the list, and the game to hang.